### PR TITLE
user agent util lib initial implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,11 @@
             <version>1.10.8</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.sf.uadetector</groupId>
+            <artifactId>uadetector-resources</artifactId>
+            <version>2014.10</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/polyfill/HelloWorldController.java
+++ b/src/main/java/org/polyfill/HelloWorldController.java
@@ -1,6 +1,10 @@
 package org.polyfill;
 
+import org.polyfill.utils.UserAgent;
+import org.polyfill.utils.UserAgentImpl;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -18,4 +22,13 @@ public class HelloWorldController {
         return "Hello World";
     }
 
+    @RequestMapping(value = "/user-agent-test", method = RequestMethod.GET)
+    @ResponseBody
+    public String userAgentTest(
+            @RequestHeader("User-Agent") String uaString, Model map) {
+        UserAgent ua = new UserAgentImpl(uaString);
+        map.addAttribute("user agent", ua.toString());
+
+        return map.toString();
+    }
 }

--- a/src/main/java/org/polyfill/utils/UserAgent.java
+++ b/src/main/java/org/polyfill/utils/UserAgent.java
@@ -1,0 +1,20 @@
+package org.polyfill.utils;
+
+public interface UserAgent {
+
+    String getFamily();
+
+    String getMajorVersion();
+
+    String getMinorVersion();
+
+    String getVersion();
+
+    String toString();
+
+    boolean isUnknown();
+
+    boolean meetsBaseline();
+
+    boolean satisfies(String range);
+}

--- a/src/main/java/org/polyfill/utils/UserAgentImpl.java
+++ b/src/main/java/org/polyfill/utils/UserAgentImpl.java
@@ -1,0 +1,279 @@
+package org.polyfill.utils;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import net.sf.uadetector.OperatingSystem;
+import net.sf.uadetector.ReadableUserAgent;
+import net.sf.uadetector.UserAgentStringParser;
+import net.sf.uadetector.VersionNumber;
+import net.sf.uadetector.service.UADetectorServiceFactory;
+
+// TODO: cache user agent output
+public class UserAgentImpl implements UserAgent {
+
+    // static definitions
+    private static final UserAgentStringParser uaParser = UADetectorServiceFactory.getResourceModuleParser();
+    private static final Pattern normalizePattern = Pattern.compile("^\\w+\\/\\d+(\\.\\d+(\\.\\d+)?)?$", Pattern.CASE_INSENSITIVE);
+
+    private static final Map<String, String> baselineVersions;
+    private static final Map<String, String> aliases;
+
+    // TODO: this is ugly:( need to isolate these constant maps from implementation
+    static {
+        Map<String, String> baselineVersionsInit  = new HashMap<String, String>();
+        baselineVersionsInit.put("ie", ">=7");
+        baselineVersionsInit.put("ie_mob", ">=8");
+        baselineVersionsInit.put("chrome", "*");
+        baselineVersionsInit.put("safari", ">=4");
+        baselineVersionsInit.put("ios_saf", ">=4");
+        baselineVersionsInit.put("ios_chr", ">=4");
+        baselineVersionsInit.put("firefox", ">=3.6");
+        baselineVersionsInit.put("firefox_mob", ">=4");
+        baselineVersionsInit.put("android", ">=3");
+        baselineVersionsInit.put("opera", ">=11");
+        baselineVersionsInit.put("op_mob", ">=10");
+        baselineVersionsInit.put("op_mini", ">=5");
+        baselineVersionsInit.put("bb", ">=6");
+        baselineVersionsInit.put("samsung_mob", ">=4");
+        baselineVersions = Collections.unmodifiableMap(baselineVersionsInit);
+
+        Map<String, String> aliasesInit  = new HashMap<String, String>();
+        aliasesInit.put("blackberry webkit", "bb");
+        aliasesInit.put("blackberry", "bb");
+
+        aliasesInit.put("pale moon (firefox variant)", "firefox");
+        aliasesInit.put("firefox mobile", "firefox_mob");
+        aliasesInit.put("firefox namoroka", "firefox");
+        aliasesInit.put("firefox shiretoko", "firefox");
+        aliasesInit.put("firefox minefield", "firefox");
+        aliasesInit.put("firefox alpha", "firefox");
+        aliasesInit.put("firefox beta", "firefox");
+        aliasesInit.put("microb", "firefox");
+        aliasesInit.put("mozilladeveloperpreview", "firefox");
+        aliasesInit.put("iceweasel", "firefox");
+
+        aliasesInit.put("opera tablet", "opera");
+
+        aliasesInit.put("opera mobile", "op_mob");
+        aliasesInit.put("opera mini", "op_mini");
+
+        aliasesInit.put("chrome mobile", "chrome");
+        aliasesInit.put("chrome frame", "chrome");
+        aliasesInit.put("chromium", "chrome");
+
+        aliasesInit.put("ie mobile", "ie_mob");
+
+        aliasesInit.put("ie large screen", "ie");
+        aliasesInit.put("internet explorer", "ie");
+        aliasesInit.put("edge", "ie");
+        aliasesInit.put("edge mobile", "ie");
+
+        aliasesInit.put("uc browser/9.9", "ie/10");
+
+        aliasesInit.put("chrome mobile ios", "ios_chr");
+
+        aliasesInit.put("mobile safari", "ios_saf");
+        aliasesInit.put("iphone", "ios_saf");
+        aliasesInit.put("iphone simulator", "ios_saf");
+        aliasesInit.put("mobile safari uiwebview", "ios_saf");
+
+        aliasesInit.put("facebook", "ios_saf");
+
+        aliasesInit.put("samsung internet", "samsung_mob");
+
+        aliasesInit.put("phantomjs", "safari/5");
+
+        aliasesInit.put("yandex browser/14.10", "chrome/37");
+        aliasesInit.put("yandex browser/14.8", "chrome/36");
+        aliasesInit.put("yandex browser/14.7", "chrome/35");
+        aliasesInit.put("yandex browser/14.5", "chrome/34");
+        aliasesInit.put("yandex browser/14.4", "chrome/33");
+        aliasesInit.put("yandex browser/14.2", "chrome/32");
+        aliasesInit.put("yandex browser/13.12", "chrome/30");
+        aliasesInit.put("yandex browser/13.10", "chrome/28");
+        aliases = Collections.unmodifiableMap(aliasesInit);
+    }
+
+    public static String normalize(String uaString) {
+        if (isNormalized(uaString)) {
+            return uaString.toLowerCase();
+        } else {
+            UserAgent ua = new UserAgentImpl(uaString);
+            return ua.toString();
+        }
+    }
+
+    public static Map<String, String> getBaselineVersions() {
+        return baselineVersions;
+    }
+
+    private static boolean isNormalized(String uaString) {
+        return normalizePattern.matcher(uaString).find();
+    }
+
+    // instance definitions
+    private ReadableUserAgent ua;
+    private String family;
+    private String majorVersion;
+    private String minorVersion;
+    private String version;
+
+    public UserAgentImpl(String userAgentString) {
+        this.ua = uaParser.parse(stripiOSWebViewBrowsers(userAgentString));
+        this.family = this.ua.getName().toLowerCase();
+
+        VersionNumber versionNumber = this.ua.getVersionNumber();
+        this.majorVersion = versionNumber.getMajor();
+        this.minorVersion = versionNumber.getMinor();
+        this.version = versionNumber.toVersionString();
+
+        resolveAlias();
+    }
+    
+    public String getFamily() {
+        return this.family;
+    }
+
+    public String getMajorVersion() {
+        return this.majorVersion;
+    }
+
+    public String getMinorVersion() {
+        return this.minorVersion;
+    }
+
+    public String getVersion() {
+        return this.version;
+    }
+
+    public boolean isUnknown() {
+        return baselineVersions.get(getFamily()) == null;
+    }
+    
+    public boolean meetsBaseline() {
+        String baselineRange = baselineVersions.get(getFamily());
+        return baselineRange != null && isVersionInRange(baselineRange);
+    }
+
+    public boolean satisfies(String range) {
+        return isVersionInRange(range) && meetsBaseline();
+    }
+
+    public String toString() {
+        return getFamily() + "/" + getVersion();
+    }
+
+    /**
+     * Chrome, Opera, and Firefox on iOS use webview, so stripping them away so that uaDetector
+     * falls back to mobile safari and we can map it to ios_saf for more accurate results
+     */
+    private String stripiOSWebViewBrowsers(String uaString) {
+        return uaString.replaceAll("((CriOS|OPiOS)\\/(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)|(FxiOS\\/(\\d+)\\.(\\d+)))", "");
+    }
+
+    /**
+     * check if user agent version is within range
+     * @param range - range of user agent version (e.g. 4 - 6, >=5, <3, *, 10 - *)
+     */
+    private boolean isVersionInRange(String range) {
+
+        double major = Double.parseDouble(getMajorVersion());
+
+        // *
+        if (range.equals("*")) {
+            return true;
+        }
+
+        // xxx - xxx
+        if (range.indexOf('-') > -1) {
+            String[] rangeParts = range.split(" - ");
+            double min = rangeParts[0].equals("*") ? 0 : Double.parseDouble(rangeParts[0]);
+            double max = rangeParts[1].equals("*") ? Double.MAX_VALUE : Double.parseDouble(rangeParts[1]);
+            return major >= min && major <= max;
+        }
+
+        // </<=/>/>=xxx
+        if (range.charAt(0) == '<') {
+            if (range.charAt(1) == '=') {
+                double max = Double.parseDouble(range.substring(2));
+                return major <= max;
+            } else {
+                double max = Double.parseDouble(range.substring(1));
+                return major < max;
+            }
+        }
+
+        if (range.charAt(0) == '>') {
+            if (range.charAt(1) == '=') {
+                double max = Double.parseDouble(range.substring(2));
+                return major >= max;
+            } else {
+                double max = Double.parseDouble(range.substring(1));
+                return major > max;
+            }
+        }
+
+        // range is a specific version
+        if (range.indexOf('.') > -1) {
+            String[] rangeParts = range.split("\\.");
+            String[] versionParts = getVersion().split("\\.");
+            // if range is more specific than version, version
+            // cannot be in range
+            if (rangeParts.length > versionParts.length) {
+                return false;
+            }
+            for (int i = 0; i < rangeParts.length; i++) {
+                if (!rangeParts[i].equals(versionParts[i])) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        // range only checks for major version
+        return getMajorVersion().equals(range);
+    }
+
+    /**
+     * update the attributes of this class based on the new
+     * userAgent string
+     * @param userAgent - simple user agent (e.g. ios_saf/10.0.2) to update our attributes
+     */
+    private void updateUA(String userAgent) {
+        String[] aliasParts = userAgent.split("/");
+        this.family = aliasParts[0];
+        if (aliasParts.length > 1) {
+            this.version = aliasParts[1];
+
+            String[] versionParts = aliasParts[1].split("\\.");
+            this.majorVersion = versionParts[0];
+            if (versionParts.length > 1) this.minorVersion = versionParts[1];
+        }
+    }
+
+    /**
+     * convert ua family to caniuse name equivalents
+     */
+    private void resolveAlias() {
+        // Try getting the alias from the mapping
+        // browserName or browserName/Major or browserName/Major.Minor
+        String userAgent = aliases.get(getFamily());
+        userAgent = userAgent != null ? userAgent : aliases.get(getFamily() + "/" + getMajorVersion());
+        userAgent = userAgent != null ? userAgent : aliases.get(getFamily() + "/" + getMajorVersion() + "." + getMinorVersion());
+
+        // if facebook mobile is on iOS, it's using native webview
+        if ("facebook".equals(getFamily()) || "ios_saf".equals(userAgent)) {
+            OperatingSystem os = this.ua.getOperatingSystem();
+            if (os.getFamilyName().toLowerCase().equals("ios")) {
+                VersionNumber osVersion = os.getVersionNumber();
+                userAgent = userAgent + "/" + osVersion.toVersionString();
+            }
+        }
+        if (userAgent != null) {
+            updateUA(userAgent);
+        }
+    }
+}

--- a/src/test/java/org/polyfill/utils/UserAgentImplTest.java
+++ b/src/test/java/org/polyfill/utils/UserAgentImplTest.java
@@ -1,0 +1,186 @@
+package org.polyfill.utils;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by smo on 10/11/16.
+ */
+public class UserAgentImplTest {
+
+    private final static Map<String, String> UAStrings;
+    static {
+        UAStrings = new HashMap<String, String>();
+        UAStrings.put("chrome0", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2227.0 Safari/537.36");
+        UAStrings.put("chrome1", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2227.1 Safari/537.36");
+        UAStrings.put("safari", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.75.14 (KHTML, like Gecko) Version/7.0.3 Safari/7046A194A");
+        UAStrings.put("unknown", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) NewBrowser/53.0.2785.116 Yoyo/537.36");
+        UAStrings.put("edge", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246");
+        UAStrings.put("lumia950", "Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 950) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Mobile Safari/537.36 Edge/13.10586");
+
+        UAStrings.put("chrome_ios", "Mozilla/5.0 (iPhone; CPU iPhone OS 10_0_2 like Mac OS X) AppleWebKit/601.1 (KHTML, like Gecko) CriOS/53.0.2785.109 Mobile/14A456 Safari/601.1.46");
+        UAStrings.put("safari_ios", "Mozilla/5.0 (iPhone; CPU iPhone OS 10_0_2 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) Version/10.0 Mobile/14A456 Safari/602.1");
+
+        UAStrings.put("ie7", "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; chromeframe/12.0.742.100)");
+        UAStrings.put("ie6", "Mozilla/4.0 (compatible; MSIE 6.1; Windows XP; .NET CLR 1.1.4322; .NET CLR 2.0.50727)");
+
+        UAStrings.put("firefox25", "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:25.0) Gecko/20100101 Firefox/25.0");
+        UAStrings.put("firefox24", "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:24.0) Gecko/20100101 Firefox/24.0");
+        UAStrings.put("firefox3_5", "Mozilla/5.0 (X11;U; Linux i686; en-GB; rv:1.9.1) Gecko/20090624 Ubuntu/9.04 (jaunty) Firefox/3.5");
+    }
+
+    @Test
+    public void testGeneralUAInfo() {
+        UserAgent ua = new UserAgentImpl(UAStrings.get("chrome0"));
+        assertEquals("Browser family name incorrect", "chrome", ua.getFamily());
+        assertEquals("Major version incorrect", "41", ua.getMajorVersion());
+        assertEquals("Minor version incorrect", "0", ua.getMinorVersion());
+        assertEquals("Version number incorrect", "41.0.2227.0", ua.getVersion());
+        assertEquals("User Agent should not be unknown", false, ua.isUnknown());
+        assertEquals("toString should be in format family/version", "chrome/41.0.2227.0", ua.toString());
+    }
+
+    @Test
+    public void testUnknownBrowser() {
+        UserAgent ua = new UserAgentImpl(UAStrings.get("unknown"));
+        assertEquals("User Agent should be unknown", true, ua.isUnknown());
+    }
+
+    @Test
+    public void testMeetsBaseline() {
+        UserAgent ua = new UserAgentImpl(UAStrings.get("ie7"));
+        assertEquals("IE7 should meet the baseline", true, ua.meetsBaseline());
+    }
+
+    @Test
+    public void testNotMeetsBaseline() {
+        UserAgent ua = new UserAgentImpl(UAStrings.get("ie6"));
+        assertEquals("IE6 should not meet the baseline", false, ua.meetsBaseline());
+    }
+
+    @Test
+    public void testIOSChrome() {
+        UserAgent ua = new UserAgentImpl(UAStrings.get("chrome_ios"));
+        assertEquals("Browser family name incorrect", "ios_saf", ua.getFamily());
+        assertEquals("Version number incorrect", "10.0.2", ua.getVersion());
+    }
+
+    @Test
+    public void testSatisfiesWithMinMaxRange() {
+        UserAgent uaFF25 = new UserAgentImpl(UAStrings.get("firefox25"));
+        UserAgent uaFF24 = new UserAgentImpl(UAStrings.get("firefox24"));
+        UserAgent uaFF3_5 = new UserAgentImpl(UAStrings.get("firefox3_5"));
+        String range = "3.0 - 24";
+
+        assertSatisfies(false, range, uaFF25);
+        assertSatisfies(true, range, uaFF24);
+        assertSatisfies(false, "since it doesn't meet baseline", range, uaFF3_5);
+    }
+
+    @Test
+    public void testSatisfiesWithStar() {
+        UserAgent uaFF25 = new UserAgentImpl(UAStrings.get("firefox25"));
+        UserAgent uaFF3_5 = new UserAgentImpl(UAStrings.get("firefox3_5"));
+        String range = "*";
+
+        assertSatisfies(true, range, uaFF25);
+        assertSatisfies(false, range, uaFF3_5);
+    }
+
+    @Test
+    public void testSatisfiesWithMinStarRange() {
+        UserAgent uaFF25 = new UserAgentImpl(UAStrings.get("firefox25"));
+        UserAgent uaFF24 = new UserAgentImpl(UAStrings.get("firefox24"));
+        String range = "25 - *";
+
+        assertSatisfies(true, range, uaFF25);
+        assertSatisfies(false, range, uaFF24);
+    }
+
+    @Test
+    public void testSatisfiesWithStarMaxRange() {
+        UserAgent uaFF25 = new UserAgentImpl(UAStrings.get("firefox25"));
+        UserAgent uaFF24 = new UserAgentImpl(UAStrings.get("firefox24"));
+        String range = "* - 24";
+
+        assertSatisfies(false, range, uaFF25);
+        assertSatisfies(true, range, uaFF24);
+    }
+
+    @Test
+    public void testSatisfiesWithLessThan() {
+        UserAgent uaFF25 = new UserAgentImpl(UAStrings.get("firefox25"));
+        UserAgent uaFF24 = new UserAgentImpl(UAStrings.get("firefox24"));
+        String range = "<25";
+
+        assertSatisfies(false, range, uaFF25);
+        assertSatisfies(true, range, uaFF24);
+    }
+
+    @Test
+    public void testSatisfiesWithLessThanOrEqualTo() {
+        UserAgent uaFF25 = new UserAgentImpl(UAStrings.get("firefox25"));
+        UserAgent uaFF24 = new UserAgentImpl(UAStrings.get("firefox24"));
+        String range = "<=24";
+
+        assertSatisfies(false, range, uaFF25);
+        assertSatisfies(true, range, uaFF24);
+    }
+
+    @Test
+    public void testSatisfiesWithGreaterThan() {
+        UserAgent uaFF25 = new UserAgentImpl(UAStrings.get("firefox25"));
+        UserAgent uaFF24 = new UserAgentImpl(UAStrings.get("firefox24"));
+        String range = ">24";
+
+        assertSatisfies(true, range, uaFF25);
+        assertSatisfies(false, range, uaFF24);
+    }
+
+    @Test
+    public void testSatisfiesWithGreaterThanOrEqualTo() {
+        UserAgent uaFF25 = new UserAgentImpl(UAStrings.get("firefox25"));
+        UserAgent uaFF24 = new UserAgentImpl(UAStrings.get("firefox24"));
+        String range = ">=25";
+
+        assertSatisfies(true, range, uaFF25);
+        assertSatisfies(false, range, uaFF24);
+    }
+
+    @Test
+    public void testSatisfiesWithOnlyMajorVersion() {
+        UserAgent uaFF25 = new UserAgentImpl(UAStrings.get("firefox25"));
+        UserAgent uaFF24 = new UserAgentImpl(UAStrings.get("firefox24"));
+        String range = "25";
+
+        assertSatisfies(true, range, uaFF25);
+        assertSatisfies(false, range, uaFF24);
+    }
+
+    @Test
+    public void testSatisfiesWithExactVersion() {
+        UserAgent uaChrome0 = new UserAgentImpl(UAStrings.get("chrome0"));
+        UserAgent uaChrome1 = new UserAgentImpl(UAStrings.get("chrome1"));
+        String range = "41.0.2227.1";
+
+        assertSatisfies(false, range, uaChrome0);
+        assertSatisfies(true, range, uaChrome1);
+    }
+
+    /****************************************************************
+     * Helper Functions
+     ****************************************************************/
+    private void assertSatisfies(boolean isSatisfied, String range, UserAgent ua) {
+        assertSatisfies(isSatisfied, "", range, ua);
+    }
+
+    private void assertSatisfies(boolean isSatisfied, String reason, String range, UserAgent ua) {
+        String not = isSatisfied ? " " : " not ";
+        assertEquals("When range is " + range + ", " + ua.getFamily() + "/" + ua.getVersion() + " should" + not + "be accepted " + reason,
+                isSatisfied, ua.satisfies(range));
+    }
+}


### PR DESCRIPTION
This util is for converting user agent string to a normalized format (i.e. browserFamilyName/version) and enable comparison to the range values from all those polyfill config.json.

Tests are mostly just testing the range parser.

ToDos:
- cache the output (seems to be necessary for good performance since everyone is doing it)
- move the constant maps out