### PR TITLE
Running integration tests as part of the maven lifecycle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,81 @@
     </dependencies>
 
     <build>
+        <filters>
+            <filter>profiles/${build.profile.id}/config.properties</filter>
+        </filters>
+        <resources>
+            <resource>
+                <filtering>true</filtering>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+
         <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>1.9.1</version>
+                <executions>
+                    <execution>
+                        <id>add-integration-test-sources</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/test/integration-test/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-integration-test-resources</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>add-test-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <filtering>true</filtering>
+                                    <directory>src/integration-test/resources</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.18</version>
+                <configuration>
+                    <skipTests>${skip.unit.tests}</skipTests>
+                    <excludes>
+                        <exclude>**/IT*.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.18</version>
+                <executions>
+                    <execution>
+                        <id>integration-tests</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <skipTests>${skip.integration.tests}</skipTests>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
@@ -252,6 +326,26 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+
+        <profile>
+            <id>unit-test</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <build.profile.id>unit-test</build.profile.id>
+                <skip.integration.tests>true</skip.integration.tests>
+                <skip.unit.tests>false</skip.unit.tests>
+            </properties>
+        </profile>
+        <profile>
+            <id>integration-test</id>
+            <properties>
+                <build.profile.id>integration-test</build.profile.id>
+                <skip.integration.tests>false</skip.integration.tests>
+                <skip.unit.tests>true</skip.unit.tests>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/profiles/dev/config.properties
+++ b/profiles/dev/config.properties
@@ -1,0 +1,1 @@
+profile=dev

--- a/profiles/integration-test/config.properties
+++ b/profiles/integration-test/config.properties
@@ -1,0 +1,1 @@
+profile=integration-test

--- a/src/test/integration-test/java/ITDummyTest.java
+++ b/src/test/integration-test/java/ITDummyTest.java
@@ -1,0 +1,15 @@
+import org.junit.Test;
+
+
+import static junit.framework.Assert.assertTrue;
+
+/**
+ * @author Bhargav Venkataraman
+ */
+public class ITDummyTest {
+
+    @Test
+    public void dummyTest() {
+        assertTrue(true);
+    }
+}


### PR DESCRIPTION
Needs a lot of refinement. Putting up this PR in case someone wants to do that refinement before i get back.
Ex. These changes are configured to pick up test suites starting with 'IT' to be run as integration tests
Source files for integration tests are currently configured to be in src/test/integration-test/java
Currently doesn't run integration tests by default
To run integration tests, run command -> mvn clean verify -P integration-test