### PR TITLE
Exclude some stuff from coverage report

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -302,7 +302,9 @@
                     <instrumentation>
                         <excludes>
                             <!-- exclude perf report runner from coverage -->
-                            <exclude>**/perf/*.class</exclude>
+                            <exclude>**/perf/**/*.class</exclude>
+                            <!-- exclude configurations coverage -->
+                            <exclude>**/configurations/*.class</exclude>
                         </excludes>
                     </instrumentation>
                 </configuration>


### PR DESCRIPTION
Exclude the following from coverage report:
- Perf - Doesn't make sense to test perf tests.
- Configurations - These should be **indirectly** tested in integration tests.