### PR TITLE
Central deployment setup

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,5 @@
 #!/usr/local/env bash
 
 if [ "$TRAVIS_BRANCH" = 'master' ] && [ "$TRAVIS_PULL_REQUEST" == 'false' ]; then
-    mvn deploy --settings settings.xml
+    mvn deploy -P release --settings settings.xml
 fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,5 @@
 #!/usr/local/env bash
 
 if [ "$TRAVIS_BRANCH" = 'master' ] && [ "$TRAVIS_PULL_REQUEST" == 'false' ]; then
-    mvn deploy -P release --settings settings.xml
+    mvn deploy -P ossrh --settings settings.xml
 fi

--- a/polyfill-service-perf/pom.xml
+++ b/polyfill-service-perf/pom.xml
@@ -44,14 +44,6 @@
                     <mainClass>org.polyfillservice.perf.Runner</mainClass>
                 </configuration>
             </plugin>
-            <!-- skip deployment for this; not a library -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/polyfill-service-web/pom.xml
+++ b/polyfill-service-web/pom.xml
@@ -50,14 +50,6 @@
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
             </plugin>
-            <!-- skip deployment for this; not a library -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <!-- project info for properties file -->
-        <project.version>${version}</project.version>
+        <project.version>${project.version}</project.version>
         <project.url>https://github.com/reiniergs/polyfill-service</project.url>
         <!-- some versions -->
         <jettyVersion>9.4.0.v20161208</jettyVersion>
@@ -102,14 +102,12 @@
 
     <distributionManagement>
         <repository>
-            <id>repo.auraframework.org</id>
-            <name>repo.auraframework.org-releases</name>
-            <url>http://repo.auraframework.org/libs-release-local</url>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
         </repository>
         <snapshotRepository>
-            <id>repo.auraframework.org</id>
-            <name>repo.auraframework.org-snapshots</name>
-            <url>http://repo.auraframework.org/libs-snapshot-local</url>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
 
@@ -208,6 +206,17 @@
                             </configuration>
                         </execution>
                     </executions>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>1.6</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>1.6.8</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -357,19 +366,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 
@@ -435,14 +431,13 @@
         </profile>
 
         <profile>
-            <id>release</id>
+            <id>ossrh</id>
             <build>
                 <plugins>
-                <!--
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
+                        <version>1.6</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -453,11 +448,10 @@
                             </execution>
                         </executions>
                     </plugin>
-
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.7</version>
+                        <version>1.6.8</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>
@@ -465,14 +459,13 @@
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
                         </configuration>
                     </plugin>
-                -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>2.10.4</version>
                         <executions>
                             <execution>
-                                <id>attach-sources</id>
+                                <id>attach-javadocs</id>
                                 <goals>
                                     <goal>jar</goal>
                                 </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -207,17 +207,6 @@
                         </execution>
                     </executions>
                 </plugin>
-
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-gpg-plugin</artifactId>
-                    <version>1.6</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.6.8</version>
-                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -68,15 +68,13 @@
     <developers>
         <developer>
             <name>Shaocong Mo</name>
-            <email>scottscmo@gmail.com</email>
+            <email>polyfill-service@googlegroups.com</email>
         </developer>
         <developer>
             <name>Reinier Guerra Sicilia</name>
-            <email>reinier@gmail.com</email>
         </developer>
         <developer>
             <name>Bhargav Venkataraman</name>
-            <email>vbhargavmbis@gmail.com</email>
         </developer>
     </developers>
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         </developer>
         <developer>
             <name>Bhargav Venkataraman</name>
-            <email>TODO</email>
+            <email>vbhargavmbis@gmail.com</email>
         </developer>
     </developers>
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,21 @@
         </license>
     </licenses>
 
+    <developers>
+        <developer>
+            <name>Shaocong Mo</name>
+            <email>scottscmo@gmail.com</email>
+        </developer>
+        <developer>
+            <name>Reinier Guerra Sicilia</name>
+            <email>reinier@gmail.com</email>
+        </developer>
+        <developer>
+            <name>Bhargav Venkataraman</name>
+            <email>TODO</email>
+        </developer>
+    </developers>
+
     <modules>
         <module>polyfill-service-api</module>
         <module>polyfill-service-rest</module>
@@ -325,18 +340,12 @@
                     <sourceEncoding>UTF-8</sourceEncoding>
                 </configuration>
             </plugin>
-            <!-- java docs and sources jar -->
+            <!-- generate docs for web app -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.10.4</version>
                 <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
                     <execution>
                         <id>aggregate</id>
                         <goals>
@@ -422,6 +431,68 @@
                                 </fileset>
                             </filesets>
                         </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                <!--
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.5</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.7</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>2.10.4</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.0.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/settings.xml
+++ b/settings.xml
@@ -4,21 +4,21 @@
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
     <servers>
         <server>
-            <id>repo.auraframework.org</id>
-            <username>${env.PS_REPO_USERNAME}</username>
-            <password>${env.PS_REPO_PASSWORD}</password>
+            <id>ossrh</id>
+            <username>polyfillservice</username>
+            <password>{Ut1ipm/G+EsHapowus/U7YSq9tLIf5q5VNXjy8xtVBQ=}</password>
         </server>
     </servers>
 
     <profiles>
         <profile>
-            <id>ossrh</id>
+            <id>gpg</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
                 <gpg.executable>gpg2</gpg.executable>
-                <gpg.passphrase>${env.PS_GPG_PSWD}</gpg.passphrase>
+                <gpg.passphrase>Shaocong created this key. Will expire in 2019-06-26. {MTh/1yE4zrMH/rKmrQ4apNUiwCMRdf9KnyRO+EQRVcqpRyg5LS9NpcvORC858G3c}</gpg.passphrase>
             </properties>
         </profile>
     </profiles>

--- a/settings.xml
+++ b/settings.xml
@@ -9,4 +9,17 @@
             <password>${env.PS_REPO_PASSWORD}</password>
         </server>
     </servers>
+
+    <profiles>
+        <profile>
+            <id>ossrh</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <gpg.executable>gpg2</gpg.executable>
+                <gpg.passphrase>${env.PS_GPG_PSWD}</gpg.passphrase>
+            </properties>
+        </profile>
+    </profiles>
 </settings>


### PR DESCRIPTION
Remove aura artifactory repo
Setup maven central deployment
- This is not automated. It requires password entry for gpg signing. It's supposed to bypass that since I've already define the passphrase in the settings.xml, but it's not working...maybe it requires a different gpg version?
- For now we have to upload all the modules. We cannot skip the last module (perf) built in the reactor build order due to nexus-staging-plugin's limitation, so might as well include everything. On the official site they even say we should create a dummy module to get around this...not something I would like to do :( We might be able to do it some other way, but yea.
- To push to central, you'll need to get the settings-security.xml (for encrypting/decrypting password in settings.xml) and a password from me (for decrypting gpg's password and use that to sign artifacts if prompted).
`mvn deploy -P ossrh --settings settings.xml`

[Warning] We cannot remove releases once they are uploaded...

#159 