### PR TITLE
Fixing IE11 Symbol polyfill issue

### DIFF
--- a/polyfill-service-api/polyfills/Symbol/toStringTag/polyfill.js
+++ b/polyfill-service-api/polyfills/Symbol/toStringTag/polyfill.js
@@ -1,11 +1,12 @@
 (function() {
+	var objToString = Object.prototype.toString;
 	Object.defineProperty(Symbol, 'toStringTag', {
 		value: Symbol('toStringTag')
 	});
 
 	var descriptor = Object.getOwnPropertyDescriptor(Object.prototype, 'toString');
 	descriptor.value = function () {
-		var str = toString.call(this),
+		var str = objToString.call(this),
 			tst = this[Symbol.toStringTag]
 		;
 		return typeof tst === 'undefined' ? str : ('[object ' + tst + ']');


### PR DESCRIPTION
Function `toString` was expected to be declared within the same scope, but because the polyfill service creates its own closure, its getting the wrong scoped version.