### PR TITLE
Service Config New Features + API Changes

### DIFF
--- a/polyfill-service-api/README.md
+++ b/polyfill-service-api/README.md
@@ -38,28 +38,29 @@ public PolyfillServiceConfigLocation serviceConfigLocation() {
 
 <a name="configurations"></a>
 ### Configurations
-Polyfill Service provides some options to customize the behavior of fetching polyfills.
-- minified
+Polyfill Service provides some options to customize the behavior of loading and fetching polyfills.
+- minified (default: true)
     - whether to minify polyfills
-- gated
+- gated (default: true)
     - whether to gate polyfill with if (polyfill exists)
     - can be global or specific to a polyfill
-- loadOnUnknownUA
+- load-on-unknown-ua (default: true)
     - whether to load polyfills when user agent is unknown
+- debug-mode (default: false)
+    - whether to prepend polyfills with debug info
 - polyfills
-    - polyfills to fetch
+    - when specified, only these polyfills are loaded into memory for fetching, including their dependencies 
+        - these are also the polyfills to fetch when no Query object is supplied
     - can be alias group like es6 that contains multiple polyfills
 
 e.g.
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <configurations>
-    <!-- gate all polyfills. default: true -->
     <gated>true</gated>
-    <!-- send minified source. default: true -->
     <minify>true</minify>
-    <!-- load polyfills when user agent is unknown. default: true -->
     <load-on-unknown-ua>true</load-on-unknown-ua>
+    <debug-mode>true</debug-mode>
 
     <polyfills>
         <polyfill>es6</polyfill>
@@ -76,7 +77,9 @@ e.g.
 PolyfillService polyfillService;
 ...
 // fetch with a user agent string and an optional query config object
-// without query object, it will load all the polyfills, filtered by the user agent string
+// without query object, it will load all the polyfills
+// or the polyfills defined in service config
+// filtered by the user agent string
 String output = polyfillService.getPolyfillsSource(userAgentString);
 ```
 

--- a/polyfill-service-api/src/main/java/org/polyfillservice/api/components/Query.java
+++ b/polyfill-service-api/src/main/java/org/polyfillservice/api/components/Query.java
@@ -1,6 +1,8 @@
 package org.polyfillservice.api.components;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -10,29 +12,28 @@ import java.util.Set;
  * Config object used to retrieve polyfills
  */
 public class Query {
-    // features to request
-    private List<Feature> features;
-
-    // filters
+    private List<Feature> features = new ArrayList<>();
     private Set<String> excludes = new HashSet<>();
-    private boolean loadOnUnknownUA = true;
-    private boolean minify = true;
-    private boolean gatedForAll = true;
-    private boolean alwaysForAll = false;
 
-    // extra options
-    private boolean includeDependencies = true;
+    // using Boolean object to indicate 3 states: true, false, null(unset)
+    private Boolean shouldMinify;
+    private Boolean shouldGateForAll;
+    private Boolean shouldAlwaysLoadForAll;
+    private Boolean shouldLoadOnUnknownUA;
+    private Boolean shouldIncludeDependencies;
+    private Boolean isDebugMode;
 
     private Query() {}
 
     private Query(Query query) {
         this.features = query.features;
         this.excludes = query.excludes;
-        this.loadOnUnknownUA = query.loadOnUnknownUA;
-        this.minify = query.minify;
-        this.gatedForAll = query.gatedForAll;
-        this.alwaysForAll = query.alwaysForAll;
-        this.includeDependencies = query.includeDependencies;
+        this.shouldMinify = query.shouldMinify;
+        this.shouldGateForAll = query.shouldGateForAll;
+        this.shouldAlwaysLoadForAll = query.shouldAlwaysLoadForAll;
+        this.shouldLoadOnUnknownUA = query.shouldLoadOnUnknownUA;
+        this.shouldIncludeDependencies = query.shouldIncludeDependencies;
+        this.isDebugMode = query.isDebugMode;
     }
 
     public List<Feature> getFeatures() {
@@ -43,69 +44,89 @@ public class Query {
         return this.excludes;
     }
 
-    public boolean shouldLoadOnUnknownUA() {
-        return this.loadOnUnknownUA;
+    public Boolean shouldMinify() {
+        return this.shouldMinify;
     }
 
-    public boolean shouldIncludeDependencies() {
-        return this.includeDependencies;
+    public Boolean shouldGateForAll() {
+        return this.shouldGateForAll;
     }
 
-    public boolean shouldMinify() {
-        return this.minify;
+    public Boolean shouldAlwaysLoadForAll() {
+        return this.shouldAlwaysLoadForAll;
     }
 
-    public boolean isGatedForAll() {
-        return this.gatedForAll;
+    public Boolean shouldLoadOnUnknownUA() {
+        return this.shouldLoadOnUnknownUA;
     }
 
-    public boolean isAlwaysForAll() {
-        return this.alwaysForAll;
+    public Boolean shouldIncludeDependencies() {
+        return this.shouldIncludeDependencies;
+    }
+
+    public Boolean isDebugMode() {
+        return this.isDebugMode;
     }
 
     public static class Builder {
         private Query query;
 
-        public Builder(List<Feature> features) {
+        public Builder() {
             this.query = new Query();
-            this.query.features = features;
         }
 
         public Query build() {
             return new Query(this.query);
         }
 
+        public Builder includeFeatures(Collection<Feature> features) {
+            if (features != null) {
+                this.query.features.addAll(features);
+            }
+            return this;
+        }
+
         public Builder excludeFeatures(String ... features) {
-            return excludeFeatures(Arrays.asList(features));
-        }
-
-        public Builder excludeFeatures(List<String> features) {
-            this.query.excludes.addAll(features);
+            if (features != null) {
+                this.query.excludes.addAll(Arrays.asList(features));
+            }
             return this;
         }
 
-        public Builder setLoadOnUnknownUA(boolean loadOnUnknownUA) {
-            this.query.loadOnUnknownUA = loadOnUnknownUA;
+        public Builder excludeFeatures(Collection<String> features) {
+            if (features != null) {
+                this.query.excludes.addAll(features);
+            }
             return this;
         }
 
-        public Builder setMinify(boolean minify) {
-            this.query.minify = minify;
+        public Builder setMinify(boolean shouldMinify) {
+            this.query.shouldMinify = shouldMinify;
             return this;
         }
 
-        public Builder setAlwaysForAll(boolean alwaysForAll) {
-            this.query.alwaysForAll = alwaysForAll;
+        public Builder setGatedForAll(boolean shouldGateForAll) {
+            this.query.shouldGateForAll = shouldGateForAll;
             return this;
         }
 
-        public Builder setGatedForAll(boolean gatedForAll) {
-            this.query.gatedForAll = gatedForAll;
+        public Builder setAlwaysLoadForAll(boolean shouldAlwaysLoadForAll) {
+            this.query.shouldAlwaysLoadForAll = shouldAlwaysLoadForAll;
             return this;
         }
 
-        public Builder setIncludeDependencies(boolean includeDependencies) {
-            this.query.includeDependencies = includeDependencies;
+        public Builder setLoadOnUnknownUA(boolean shouldLoadOnUnknownUA) {
+            this.query.shouldLoadOnUnknownUA = shouldLoadOnUnknownUA;
+            return this;
+        }
+
+        public Builder setIncludeDependencies(boolean shouldIncludeDependencies) {
+            this.query.shouldIncludeDependencies = shouldIncludeDependencies;
+            return this;
+        }
+
+        public Builder setDebugMode(boolean isDebugMode) {
+            this.query.isDebugMode = isDebugMode;
             return this;
         }
     }

--- a/polyfill-service-api/src/main/java/org/polyfillservice/api/components/ServiceConfig.java
+++ b/polyfill-service-api/src/main/java/org/polyfillservice/api/components/ServiceConfig.java
@@ -8,26 +8,32 @@ import java.util.List;
  * Simple object to hold polyfill service configurations.
  */
 public class ServiceConfig {
-    private List<String> polyfills = Collections.emptyList();
-    private boolean gated = true;
-    private boolean minify = true;
-    private boolean loadOnUnknownUA = true;
 
-    // only construct object via builder
+    private List<String> polyfills = Collections.emptyList();
+    private boolean shouldGate = true;
+    private boolean shouldMinify = true;
+    private boolean shouldLoadOnUnknownUA = true;
+    private boolean isDebugMode = false;
+
+    // default constructor to be used by builder
     private ServiceConfig() {}
-    private ServiceConfig(ServiceConfig serviceConfig) {
-        this.polyfills = serviceConfig.polyfills;
-        this.gated = serviceConfig.gated;
-        this.minify = serviceConfig.minify;
-        this.loadOnUnknownUA = serviceConfig.loadOnUnknownUA;
+
+    // copy constructor to be used by builder
+    private ServiceConfig(ServiceConfig fromBuilder) {
+        this.shouldGate = fromBuilder.shouldGate;
+        this.shouldMinify = fromBuilder.shouldMinify;
+        this.polyfills = fromBuilder.polyfills;
+        this.isDebugMode = fromBuilder.isDebugMode;
+        this.shouldLoadOnUnknownUA = fromBuilder.shouldLoadOnUnknownUA;
     }
 
     public String toString() {
         return "ServiceConfig: {"
                 + "\n\tpolyfills: " + this.polyfills
-                + ",\n\tgated: " + this.gated
-                + ",\n\tminify: " + this.minify
-                + ",\n\tload-on-unknown-ua: " + this.loadOnUnknownUA
+                + ",\n\tshouldGate: " + this.shouldGate
+                + ",\n\tshouldMinify: " + this.shouldMinify
+                + ",\n\tload-on-unknown-ua: " + this.shouldLoadOnUnknownUA
+                + ",\n\tdebug-mode: " + this.isDebugMode
                 + "\n}";
     }
 
@@ -36,15 +42,19 @@ public class ServiceConfig {
     }
 
     public boolean shouldGate() {
-        return this.gated;
+        return this.shouldGate;
     }
 
     public boolean shouldMinify() {
-        return this.minify;
+        return this.shouldMinify;
     }
 
     public boolean shouldLoadOnUnknownUA() {
-        return this.loadOnUnknownUA;
+        return this.shouldLoadOnUnknownUA;
+    }
+
+    public boolean isDebugMode() {
+        return this.isDebugMode;
     }
 
     public static class Builder {
@@ -64,17 +74,22 @@ public class ServiceConfig {
         }
 
         public Builder setGated(boolean gated) {
-            this.serviceConfig.gated = gated;
+            this.serviceConfig.shouldGate = gated;
             return this;
         }
 
         public Builder setMinify(boolean minify) {
-            this.serviceConfig.minify = minify;
+            this.serviceConfig.shouldMinify = minify;
             return this;
         }
 
         public Builder setLoadOnUnknownUA(boolean loadOnUnknownUA) {
-            this.serviceConfig.loadOnUnknownUA = loadOnUnknownUA;
+            this.serviceConfig.shouldLoadOnUnknownUA = loadOnUnknownUA;
+            return this;
+        }
+
+        public Builder setDebugMode(boolean isDebugMode) {
+            this.serviceConfig.isDebugMode = isDebugMode;
             return this;
         }
     }

--- a/polyfill-service-api/src/main/java/org/polyfillservice/api/configurations/PolyfillApiConfig.java
+++ b/polyfill-service-api/src/main/java/org/polyfillservice/api/configurations/PolyfillApiConfig.java
@@ -1,7 +1,5 @@
 package org.polyfillservice.api.configurations;
 
-import org.polyfillservice.api.components.Feature;
-import org.polyfillservice.api.components.Query;
 import org.polyfillservice.api.components.ServiceConfig;
 import org.polyfillservice.api.interfaces.PolyfillServiceConfigLocation;
 import org.polyfillservice.api.interfaces.ServiceConfigLoaderService;
@@ -11,9 +9,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Created by reinier.guerra on 1/24/17.
@@ -25,7 +20,8 @@ import java.util.stream.Collectors;
 public class PolyfillApiConfig {
 
     @Autowired
-    ServiceConfigLoaderService serviceConfigLoaderService;
+    private ServiceConfigLoaderService serviceConfigLoaderService;
+
     @Autowired(required = false)
     private PolyfillServiceConfigLocation serviceConfigLocation;
 
@@ -48,20 +44,5 @@ public class PolyfillApiConfig {
     @Bean
     public ServiceConfig serviceConfig() {
         return serviceConfigLoaderService.loadConfig(serviceConfigLocation);
-    }
-
-    // Default query used when query object is not supplied to query service
-    @Bean
-    @Autowired
-    public Query defaultQuery(ServiceConfig serviceConfig) {
-        List<Feature> polyfillRequestList = serviceConfig.getPolyfills().stream()
-            .map(Feature::new)
-            .collect(Collectors.toList());
-
-        return new Query.Builder( polyfillRequestList )
-            .setMinify( serviceConfig.shouldMinify() )
-            .setLoadOnUnknownUA( serviceConfig.shouldLoadOnUnknownUA() )
-            .setGatedForAll( serviceConfig.shouldGate() )
-            .build();
     }
 }

--- a/polyfill-service-api/src/main/java/org/polyfillservice/api/interfaces/PolyfillService.java
+++ b/polyfill-service-api/src/main/java/org/polyfillservice/api/interfaces/PolyfillService.java
@@ -57,14 +57,4 @@ public interface PolyfillService {
      * @return source of all requested and valid polyfills
      */
     String getPolyfillsSource(String uaString, Query query);
-
-    /**
-     * Return a string of the sources of requested polyfills
-     * Alias polyfill will expand into specific polyfills.
-     * @param uaString user agent string; can be in normalized format e.g. chrome/53.0.0
-     * @param query config object with information about what polyfills to get
-     * @param isDebugMode whether to add debug information in the header before the polyfills source
-     * @return source of all requested and valid polyfills
-     */
-    String getPolyfillsSource(String uaString, Query query, boolean isDebugMode);
 }

--- a/polyfill-service-api/src/main/java/org/polyfillservice/api/services/PolyfillsOutputService.java
+++ b/polyfill-service-api/src/main/java/org/polyfillservice/api/services/PolyfillsOutputService.java
@@ -25,9 +25,8 @@ class PolyfillsOutputService {
     @Resource(name = "projectUrl")
     private String projectUrl;
 
-    public String getPolyfillsSource(String uaString, Query query,
-                                     List<Feature> featuresLoaded, boolean isDebugMode) {
-        String debugInfo = isDebugMode ? getDebugInfo(uaString, query, featuresLoaded): "";
+    public String getPolyfillsSource(String uaString, Query query, List<Feature> featuresLoaded) {
+        String debugInfo = query.isDebugMode() ? getDebugInfo(uaString, query, featuresLoaded): "";
         String sources = getSources(featuresLoaded, query.shouldMinify());
         String separator = !debugInfo.isEmpty() && !sources.isEmpty() ? "\n\n" : "";
         return debugInfo + separator + sources;

--- a/polyfill-service-api/src/main/java/org/polyfillservice/api/services/PreSortPolyfillService.java
+++ b/polyfill-service-api/src/main/java/org/polyfillservice/api/services/PreSortPolyfillService.java
@@ -38,9 +38,9 @@ class PreSortPolyfillService implements PolyfillService {
     private Map<String, String> browserBaselines;
     @Resource(name = "aliases")
     private Map<String, List<String>> aliases;
-    @Resource(name = "serviceConfig")
-    private ServiceConfig serviceConfig;
 
+    @Autowired
+    private ServiceConfig serviceConfig;
     @Autowired
     private VersionUtilService versionChecker;
     @Autowired

--- a/polyfill-service-api/src/main/java/org/polyfillservice/api/services/PreSortPolyfillService.java
+++ b/polyfill-service-api/src/main/java/org/polyfillservice/api/services/PreSortPolyfillService.java
@@ -3,6 +3,7 @@ package org.polyfillservice.api.services;
 import org.polyfillservice.api.components.Feature;
 import org.polyfillservice.api.components.Polyfill;
 import org.polyfillservice.api.components.Query;
+import org.polyfillservice.api.components.ServiceConfig;
 import org.polyfillservice.api.components.TSort;
 import org.polyfillservice.api.interfaces.PolyfillService;
 import org.polyfillservice.api.interfaces.UserAgent;
@@ -13,7 +14,13 @@ import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.Resource;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -27,29 +34,39 @@ class PreSortPolyfillService implements PolyfillService {
 
     @Resource(name = "polyfills")
     private Map<String, Polyfill> polyfills;
-
     @Resource(name = "browserBaselines")
     private Map<String, String> browserBaselines;
-
     @Resource(name = "aliases")
     private Map<String, List<String>> aliases;
-
-    @Resource(name = "defaultQuery")
-    private Query defaultQuery;
+    @Resource(name = "serviceConfig")
+    private ServiceConfig serviceConfig;
 
     @Autowired
     private VersionUtilService versionChecker;
-
     @Autowired
     private UserAgentParserService userAgentParserService;
-
     @Autowired
     private PolyfillsOutputService polyfillsOutputService;
 
     private List<String> sortedPolyfills;
+    private Query defaultQuery;
 
     @PostConstruct
     public void init() {
+        List<Feature> polyfillRequestList = serviceConfig.getPolyfills().stream()
+            .map(Feature::new)
+            .collect(Collectors.toList());
+
+        this.defaultQuery = new Query.Builder()
+            .includeFeatures(polyfillRequestList)
+            .setMinify(serviceConfig.shouldMinify())
+            .setGatedForAll(serviceConfig.shouldGate())
+            .setAlwaysLoadForAll(false)
+            .setLoadOnUnknownUA(serviceConfig.shouldLoadOnUnknownUA())
+            .setIncludeDependencies(true)
+            .setDebugMode(serviceConfig.isDebugMode())
+            .build();
+
         this.sortedPolyfills = getDependencySortedPolyfills(this.polyfills);
     }
 
@@ -69,28 +86,42 @@ class PreSortPolyfillService implements PolyfillService {
     }
 
     @Override
-    public List<Polyfill> getPolyfills(String uaString, Query query) {
+    public List<Polyfill> getPolyfills(String uaString, Query userQuery) {
         UserAgent userAgent = uaString == null ? null : this.userAgentParserService.parse(uaString);
+        Query query = mergeDefaultOptions(userQuery);
         return getFeatures(userAgent, query).stream()
-                .map(feature -> feature.getPolyfill())
+                .map(Feature::getPolyfill)
                 .collect(Collectors.toList());
     }
 
     @Override
     public String getPolyfillsSource(String uaString) {
-        return getPolyfillsSource(uaString, this.defaultQuery, false);
+        return getPolyfillsSource(uaString, this.defaultQuery);
     }
 
     @Override
-    public String getPolyfillsSource(String uaString, Query query) {
-        return getPolyfillsSource(uaString, query, false);
-    }
-
-    @Override
-    public String getPolyfillsSource(String uaString, Query query, boolean isDebugMode) {
+    public String getPolyfillsSource(String uaString, Query userQuery) {
         UserAgent userAgent = uaString == null ? null : this.userAgentParserService.parse(uaString);
+        Query query = mergeDefaultOptions(userQuery);
         List<Feature> featuresLoaded = getFeatures(userAgent, query);
-        return polyfillsOutputService.getPolyfillsSource(userAgent.toString(), query, featuresLoaded, isDebugMode);
+        return polyfillsOutputService.getPolyfillsSource(userAgent.toString(), query, featuresLoaded);
+    }
+
+    private Query mergeDefaultOptions(Query query) {
+        if (query == this.defaultQuery) {
+            return query;
+        }
+
+        return new Query.Builder()
+            .includeFeatures(query.getFeatures().isEmpty() ? this.defaultQuery.getFeatures() : query.getFeatures())
+            .excludeFeatures(query.getExcludes().isEmpty() ? this.defaultQuery.getExcludes() : query.getExcludes())
+            .setMinify(query.shouldMinify() == null ? this.defaultQuery.shouldMinify() : query.shouldMinify())
+            .setGatedForAll(query.shouldGateForAll() == null ? this.defaultQuery.shouldGateForAll() : query.shouldGateForAll())
+            .setAlwaysLoadForAll(query.shouldAlwaysLoadForAll() == null ? this.defaultQuery.shouldAlwaysLoadForAll() : query.shouldAlwaysLoadForAll())
+            .setLoadOnUnknownUA(query.shouldLoadOnUnknownUA() == null ? this.defaultQuery.shouldLoadOnUnknownUA() : query.shouldLoadOnUnknownUA())
+            .setIncludeDependencies(query.shouldIncludeDependencies() == null ? this.defaultQuery.shouldIncludeDependencies() : query.shouldIncludeDependencies())
+            .setDebugMode(query.isDebugMode() == null ? this.defaultQuery.isDebugMode() : query.isDebugMode())
+            .build();
     }
 
     /**
@@ -108,8 +139,8 @@ class PreSortPolyfillService implements PolyfillService {
 
         Map<String, Feature> featureSet = new HashMap<>();
         for (Feature feature : query.getFeatures()) {
-            if (query.isAlwaysForAll()) feature.setAlways(true);
-            if (query.isGatedForAll()) feature.setGated(true);
+            if (query.shouldAlwaysLoadForAll()) feature.setAlways(true);
+            if (query.shouldGateForAll()) feature.setGated(true);
             featureSet.put(feature.getName(), feature);
         }
 

--- a/polyfill-service-api/src/main/java/org/polyfillservice/api/services/XmlServiceConfigLoaderService.java
+++ b/polyfill-service-api/src/main/java/org/polyfillservice/api/services/XmlServiceConfigLoaderService.java
@@ -41,7 +41,10 @@ public class XmlServiceConfigLoaderService implements ServiceConfigLoaderService
         // map fields to tags for different names
         xstream.alias("configurations", ServiceConfig.class);
         xstream.alias("polyfill", String.class);
-        xstream.aliasField("load-on-unknown-ua", ServiceConfig.class, "loadOnUnknownUA");
+        xstream.aliasField("gated", ServiceConfig.class, "shouldGate");
+        xstream.aliasField("minify", ServiceConfig.class, "shouldMinify");
+        xstream.aliasField("load-on-unknown-ua", ServiceConfig.class, "shouldLoadOnUnknownUA");
+        xstream.aliasField("debug-mode", ServiceConfig.class, "isDebugMode");
 
         return xstream;
     }

--- a/polyfill-service-api/src/test/java/org/polyfillservice/api/configurations/CustomServiceConfig.java
+++ b/polyfill-service-api/src/test/java/org/polyfillservice/api/configurations/CustomServiceConfig.java
@@ -1,0 +1,23 @@
+package org.polyfillservice.api.configurations;
+
+import org.polyfillservice.api.components.ServiceConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import java.util.Arrays;
+
+/**
+ * Created by smo on 8/26/17.
+ */
+@Configuration
+public class CustomServiceConfig {
+    @Primary
+    @Bean
+    public ServiceConfig serviceConfig() {
+        return new ServiceConfig.Builder()
+            .setPolyfills(Arrays.asList("a", "b", "c", "d"))
+            .setGated(false)
+            .build();
+    }
+}

--- a/polyfill-service-api/src/test/java/org/polyfillservice/api/configurations/CustomServiceConfig.java
+++ b/polyfill-service-api/src/test/java/org/polyfillservice/api/configurations/CustomServiceConfig.java
@@ -14,7 +14,7 @@ import java.util.Arrays;
 public class CustomServiceConfig {
     @Primary
     @Bean
-    public ServiceConfig serviceConfig() {
+    public ServiceConfig customServiceConfig() {
         return new ServiceConfig.Builder()
             .setPolyfills(Arrays.asList("a", "b", "c", "d"))
             .setGated(false)

--- a/polyfill-service-api/src/test/java/org/polyfillservice/api/configurations/PolyfillsConfig.java
+++ b/polyfill-service-api/src/test/java/org/polyfillservice/api/configurations/PolyfillsConfig.java
@@ -19,11 +19,7 @@ public class PolyfillsConfig {
 
     @Bean
     public ServiceConfig serviceConfig() {
-        return new ServiceConfig.Builder()
-            .setMinify(true)
-            .setLoadOnUnknownUA(true)
-            .setGated(true)
-            .build();
+        return new ServiceConfig.Builder().build();
     }
 
     @Bean

--- a/polyfill-service-api/src/test/java/org/polyfillservice/api/configurations/PolyfillsConfig.java
+++ b/polyfill-service-api/src/test/java/org/polyfillservice/api/configurations/PolyfillsConfig.java
@@ -1,13 +1,15 @@
 package org.polyfillservice.api.configurations;
 
-import org.polyfillservice.api.components.Feature;
 import org.polyfillservice.api.components.Polyfill;
-import org.polyfillservice.api.components.Query;
 import org.polyfillservice.api.components.ServiceConfig;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Created by smo on 3/4/17.
@@ -17,15 +19,10 @@ public class PolyfillsConfig {
 
     @Bean
     public ServiceConfig serviceConfig() {
-        return new ServiceConfig.Builder().build();
-    }
-
-    @Bean
-    public Query defaultQuery() {
-        return new Query.Builder(Collections.singletonList(new Feature("all")))
+        return new ServiceConfig.Builder()
             .setMinify(true)
             .setLoadOnUnknownUA(true)
-            .setGatedForAll(true)
+            .setGated(true)
             .build();
     }
 

--- a/polyfill-service-api/src/test/java/org/polyfillservice/api/services/PolyfillsOutputServiceTest.java
+++ b/polyfill-service-api/src/test/java/org/polyfillservice/api/services/PolyfillsOutputServiceTest.java
@@ -40,9 +40,12 @@ public class PolyfillsOutputServiceTest {
 
     @Test
     public void testRawNoPolyfillsLoaded() {
-        List<Feature> requestedList = Collections.singletonList(new Feature("default"));
-        Query query = new Query.Builder(requestedList).setMinify(false).build();
-        String actual = service.getPolyfillsSource(TEST_UA, query, Collections.emptyList(), true);
+        Query query = new Query.Builder()
+            .includeFeatures(Arrays.asList(new Feature("default")))
+            .setDebugMode(true)
+            .setMinify(false)
+            .build();
+        String actual = service.getPolyfillsSource(TEST_UA, query, Collections.emptyList());
         String expected =
             "/* " + PROJECT_VERSION_LINE +
             "\n * " + PROJECT_URL_LINE +
@@ -56,9 +59,12 @@ public class PolyfillsOutputServiceTest {
 
     @Test
     public void testMinNoPolyfillsLoaded() {
-        List<Feature> requestedList = Collections.singletonList(new Feature("default"));
-        Query query = new Query.Builder(requestedList).setMinify(true).build();
-        String actual = service.getPolyfillsSource(null, query, Collections.emptyList(), true);
+        Query query = new Query.Builder()
+            .includeFeatures(Arrays.asList(new Feature("default")))
+            .setDebugMode(true)
+            .setMinify(true)
+            .build();
+        String actual = service.getPolyfillsSource(null, query, Collections.emptyList());
         String expected = MIN_MESSAGE;
         assertEquals(expected, actual);
     }
@@ -119,8 +125,12 @@ public class PolyfillsOutputServiceTest {
         List<Feature> requestedList = Arrays.asList(featureRequested);
         List<Feature> loadedList = Arrays.asList(featureLoaded1, featureLoaded2);
 
-        Query query = new Query.Builder(requestedList).setMinify(minify).build();
-        String actual = service.getPolyfillsSource(TEST_UA, query, loadedList, isDebugMode);
+        Query query = new Query.Builder()
+            .includeFeatures(requestedList)
+            .setMinify(minify)
+            .setDebugMode(isDebugMode)
+            .build();
+        String actual = service.getPolyfillsSource(TEST_UA, query, loadedList);
 
         assertEquals(expected, actual);
     }
@@ -153,8 +163,12 @@ public class PolyfillsOutputServiceTest {
 
         List<Feature> featureList = Arrays.asList(feature);
 
-        Query query = new Query.Builder(featureList).setMinify(minify).build();
-        String actual = service.getPolyfillsSource(TEST_UA, query, featureList, false);
+        Query query = new Query.Builder()
+            .includeFeatures(featureList)
+            .setMinify(minify)
+            .setDebugMode(false)
+            .build();
+        String actual = service.getPolyfillsSource(TEST_UA, query, featureList);
 
         assertEquals(expected, actual);
     }

--- a/polyfill-service-api/src/test/java/org/polyfillservice/api/services/PreSortPolyfillServiceCustomServiceConfig.java
+++ b/polyfill-service-api/src/test/java/org/polyfillservice/api/services/PreSortPolyfillServiceCustomServiceConfig.java
@@ -1,0 +1,66 @@
+package org.polyfillservice.api.services;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.polyfillservice.api.components.Feature;
+import org.polyfillservice.api.components.Query;
+import org.polyfillservice.api.configurations.CustomServiceConfig;
+import org.polyfillservice.api.configurations.PolyfillsConfig;
+import org.polyfillservice.api.configurations.ProjectInfoConfig;
+import org.polyfillservice.api.interfaces.PolyfillService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static junit.framework.TestCase.assertEquals;
+
+/**
+ * Created by smo on 8/26/17.
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(
+    loader=AnnotationConfigContextLoader.class,
+    classes={PolyfillsConfig.class,
+        CustomServiceConfig.class,
+        ProjectInfoConfig.class,
+        SemVerUtilService.class,
+        UADetectorAdapterParserService.class,
+        PolyfillsOutputService.class,
+        PreSortPolyfillService.class
+    })
+public class PreSortPolyfillServiceCustomServiceConfig {
+    @Autowired
+    private PolyfillService service;
+
+    /**
+     * Without query, polyfill service should use what's defined in
+     * service config as the default query, in this case it should
+     * load all polyfills
+     */
+    @Test
+    public void testGetPolyfillsSourceCustomServiceConfigNoQuery() {
+        String actual = service.getPolyfillsSource("chrome/30");
+        String expected = "(function(undefined) {c.minb.mind.mina.min}).call('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});";
+        assertEquals(expected, actual);
+    }
+
+    /**
+     * Even though service config turns off gated flag, we still should be able to
+     * turn it on dynamically with Query object
+     */
+    @Test
+    public void testGetPolyfillsSourceCustomServiceConfigQueryOverrideDefault() {
+        List<Feature> features = Arrays.asList(new Feature("c"));
+        Query query = new Query.Builder()
+            .includeFeatures(features)
+            .setGatedForAll(true)
+            .build();
+        String actual = service.getPolyfillsSource("chrome/30", query);
+        String expected = "(function(undefined) {if(!(c.detectSource)){c.min}}).call('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});";
+        assertEquals(expected, actual);
+    }
+}

--- a/polyfill-service-api/src/test/java/org/polyfillservice/api/services/PreSortPolyfillServiceCustomServiceConfig.java
+++ b/polyfill-service-api/src/test/java/org/polyfillservice/api/services/PreSortPolyfillServiceCustomServiceConfig.java
@@ -49,6 +49,18 @@ public class PreSortPolyfillServiceCustomServiceConfig {
     }
 
     /**
+     * Polyfill service should fill the empty query object with default values
+     * So this should behave the same as if query is not supplied at all
+     */
+    @Test
+    public void testGetPolyfillsSourceCustomServiceConfigQueryUseDefault() {
+        Query query = new Query.Builder().build();
+        String actual = service.getPolyfillsSource("chrome/30", query);
+        String expected = "(function(undefined) {c.minb.mind.mina.min}).call('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});";
+        assertEquals(expected, actual);
+    }
+
+    /**
      * Even though service config turns off gated flag, we still should be able to
      * turn it on dynamically with Query object
      */

--- a/polyfill-service-api/src/test/java/org/polyfillservice/api/services/PreSortPolyfillServiceTest.java
+++ b/polyfill-service-api/src/test/java/org/polyfillservice/api/services/PreSortPolyfillServiceTest.java
@@ -37,7 +37,7 @@ public class PreSortPolyfillServiceTest {
     @Test
     public void testSearchByUserAgentMeetVersionRequirements() {
         List<Feature> features = Arrays.asList(new Feature("default"));
-        Query query = new Query.Builder(features).build();
+        Query query = new Query.Builder().includeFeatures(features).build();
         String actual = getPolyfillsRawSources("chrome/30", query);
         String expected = getMockRawSources("c", "b", "d", "a");
         assertEquals(expected, actual);
@@ -46,7 +46,7 @@ public class PreSortPolyfillServiceTest {
     @Test
     public void testSearchByUserAgentSomeNotMeetVersionRequirement() {
         List<Feature> features = Arrays.asList(new Feature("default"));
-        Query query = new Query.Builder(features).build();
+        Query query = new Query.Builder().includeFeatures(features).build();
         String actual = getPolyfillsRawSources("firefox/5", query);
         String expected = getMockRawSources("c", "a");
         assertEquals(expected, actual);
@@ -55,7 +55,10 @@ public class PreSortPolyfillServiceTest {
     @Test
     public void testUnknownUserAgentShouldReturnEmpty() {
         List<Feature> features = Arrays.asList(new Feature("default"));
-        Query query = new Query.Builder(features).setLoadOnUnknownUA(false).build();
+        Query query = new Query.Builder()
+            .includeFeatures(features)
+            .setLoadOnUnknownUA(false)
+            .build();
         String actual = getPolyfillsRawSources("firefox/1", query);
         String expected = "";
         assertEquals(expected, actual);
@@ -64,7 +67,7 @@ public class PreSortPolyfillServiceTest {
     @Test
     public void testFeaturesAlwaysLoaded() {
         List<Feature> features = Arrays.asList(new Feature("default", false, true));
-        Query query = new Query.Builder(features).build();
+        Query query = new Query.Builder().includeFeatures(features).build();
         String actual = getPolyfillsRawSources("firefox/5", query);
         String expected = getMockRawSources("c", "b", "d", "a");
         assertEquals(expected, actual);
@@ -73,7 +76,10 @@ public class PreSortPolyfillServiceTest {
     @Test
     public void testUserAgentNotMeetBaselineNullifyAlwaysFlag() {
         List<Feature> features = Arrays.asList(new Feature("default", false, true));
-        Query query = new Query.Builder(features).setLoadOnUnknownUA(false).build();
+        Query query = new Query.Builder()
+            .includeFeatures(features)
+            .setLoadOnUnknownUA(false)
+            .build();
         String actual = getPolyfillsRawSources("firefox/1", query);
         String expected = "";
         assertEquals(expected, actual);
@@ -82,7 +88,7 @@ public class PreSortPolyfillServiceTest {
     @Test
     public void testNoFeaturesShouldReturnEmpty() {
         List<Feature> features = Collections.emptyList();
-        Query query = new Query.Builder(features).build();
+        Query query = new Query.Builder().includeFeatures(features).build();
         String actual = getPolyfillsRawSources(null, query);
         String expected = "";
         assertEquals(expected, actual);
@@ -91,7 +97,7 @@ public class PreSortPolyfillServiceTest {
     @Test
     public void testSearchBySingleFeature() {
         List<Feature> features = Arrays.asList(new Feature("c"));
-        Query query = new Query.Builder(features).build();
+        Query query = new Query.Builder().includeFeatures(features).build();
         String actual = getPolyfillsRawSources(null, query);
         String expected = getMockRawSources("c");
         assertEquals(expected, actual);
@@ -100,7 +106,7 @@ public class PreSortPolyfillServiceTest {
     @Test
     public void testSearchByMultipleFeatures() {
         List<Feature> features = Arrays.asList(new Feature("c"), new Feature("e"));
-        Query query = new Query.Builder(features).build();
+        Query query = new Query.Builder().includeFeatures(features).build();
         String actual = getPolyfillsRawSources(null, query);
         String expected = getMockRawSources("c", "e");
         assertEquals(expected, actual);
@@ -109,7 +115,7 @@ public class PreSortPolyfillServiceTest {
     @Test
     public void testSearchBySingleAlias() {
         List<Feature> features = Arrays.asList(new Feature("foo"));
-        Query query = new Query.Builder(features).build();
+        Query query = new Query.Builder().includeFeatures(features).build();
         String actual = getPolyfillsRawSources(null, query);
         String expected = getMockRawSources("c", "e");
         assertEquals(expected, actual);
@@ -118,7 +124,7 @@ public class PreSortPolyfillServiceTest {
     @Test
     public void testSearchByMultipleAliases() {
         List<Feature> features = Arrays.asList(new Feature("default"), new Feature("foo"));
-        Query query = new Query.Builder(features).build();
+        Query query = new Query.Builder().includeFeatures(features).build();
         String actual = getPolyfillsRawSources(null, query);
         String expected = getMockRawSources("c", "e", "b", "d", "a");
         assertEquals(expected, actual);
@@ -127,7 +133,7 @@ public class PreSortPolyfillServiceTest {
     @Test
     public void testSearchByMixingAliasAndFeature() {
         List<Feature> features = Arrays.asList(new Feature("default"), new Feature("e"));
-        Query query = new Query.Builder(features).build();
+        Query query = new Query.Builder().includeFeatures(features).build();
         String actual = getPolyfillsRawSources(null, query);
         String expected = getMockRawSources("c", "e", "b", "d", "a");
         assertEquals(expected, actual);
@@ -136,7 +142,10 @@ public class PreSortPolyfillServiceTest {
     @Test
     public void testExcludesFeatures() {
         List<Feature> features = Arrays.asList(new Feature("default"));
-        Query query = new Query.Builder(features).excludeFeatures("c", "b").build();
+        Query query = new Query.Builder()
+            .includeFeatures(features)
+            .excludeFeatures("c", "b")
+            .build();
         String actual = getPolyfillsRawSources(null, query);
         String expected = getMockRawSources("d", "a");
         assertEquals(expected, actual);
@@ -145,7 +154,10 @@ public class PreSortPolyfillServiceTest {
     @Test
     public void testCannotExcludeAlias() {
         List<Feature> features = Arrays.asList(new Feature("default"));
-        Query query = new Query.Builder(features).excludeFeatures("es6").build();
+        Query query = new Query.Builder()
+            .includeFeatures(features)
+            .excludeFeatures("es6")
+            .build();
         String actual = getPolyfillsRawSources(null, query);
         String expected = getMockRawSources("c", "b", "d", "a");
         assertEquals(expected, actual);
@@ -154,7 +166,7 @@ public class PreSortPolyfillServiceTest {
     @Test
     public void testDoMinify() {
         List<Feature> features = Arrays.asList(new Feature("default"));
-        Query query = new Query.Builder(features).build();
+        Query query = new Query.Builder().includeFeatures(features).build();
         String actual = getPolyfillsMinSources(null, query);
         String expected = getMockMinSources("c", "b", "d", "a");
         assertEquals(expected, actual);
@@ -163,7 +175,10 @@ public class PreSortPolyfillServiceTest {
     @Test
     public void testLoadOnUnknownUA() {
         List<Feature> features = Arrays.asList(new Feature("c"));
-        Query query = new Query.Builder(features).setLoadOnUnknownUA(true).build();
+        Query query = new Query.Builder()
+            .includeFeatures(features)
+            .setLoadOnUnknownUA(true)
+            .build();
         String actual = getPolyfillsRawSources("unknown/0.0.0", query);
         String expected = getMockRawSources("c");
         assertEquals(expected, actual);

--- a/polyfill-service-api/src/test/java/org/polyfillservice/api/services/PreSortPolyfillServiceTest.java
+++ b/polyfill-service-api/src/test/java/org/polyfillservice/api/services/PreSortPolyfillServiceTest.java
@@ -3,6 +3,7 @@ package org.polyfillservice.api.services;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.polyfillservice.api.components.Feature;
+import org.polyfillservice.api.components.Polyfill;
 import org.polyfillservice.api.components.Query;
 import org.polyfillservice.api.configurations.PolyfillsConfig;
 import org.polyfillservice.api.configurations.ProjectInfoConfig;
@@ -32,186 +33,181 @@ import static junit.framework.TestCase.assertEquals;
 public class PreSortPolyfillServiceTest {
 
     @Autowired
-    private PolyfillService polyfillService;
+    private PolyfillService service;
 
     @Test
-    public void testSearchByUserAgentMeetVersionRequirements() {
-        List<Feature> features = Arrays.asList(new Feature("default"));
-        Query query = new Query.Builder().includeFeatures(features).build();
-        String actual = getPolyfillsRawSources("chrome/30", query);
-        String expected = getMockRawSources("c", "b", "d", "a");
-        assertEquals(expected, actual);
+    public void testGetPolyfill() {
+        Polyfill polyfill = service.getPolyfill("a");
+        assertEquals("a", polyfill.getName());
     }
 
     @Test
-    public void testSearchByUserAgentSomeNotMeetVersionRequirement() {
-        List<Feature> features = Arrays.asList(new Feature("default"));
-        Query query = new Query.Builder().includeFeatures(features).build();
-        String actual = getPolyfillsRawSources("firefox/5", query);
-        String expected = getMockRawSources("c", "a");
-        assertEquals(expected, actual);
+    public void testGetPolyfillsWithNoServiceConfigPolyfillsAndNoQuery() {
+        List<Polyfill> polyfills = service.getPolyfills("chrome/30");
+        String polyfillNames = polyfillListToString(polyfills);
+        assertEquals("", polyfillNames);
     }
 
     @Test
-    public void testUnknownUserAgentShouldReturnEmpty() {
+    public void testGetPolyfillsUserAgentMeetVersionRequirements() {
+        List<Feature> features = Arrays.asList(new Feature("default"));
+        Query query = new Query.Builder().includeFeatures(features).build();
+        List<Polyfill> polyfills = service.getPolyfills("chrome/30", query);
+        assertEquals("cbda", polyfillListToString(polyfills));
+    }
+
+    @Test
+    public void testGetPolyfillsUserAgentSomeNotMeetVersionRequirement() {
+        List<Feature> features = Arrays.asList(new Feature("default"));
+        Query query = new Query.Builder().includeFeatures(features).build();
+        List<Polyfill> polyfills = service.getPolyfills("firefox/5", query);
+        assertEquals("ca", polyfillListToString(polyfills));
+    }
+
+    @Test
+    public void testGetPolyfillsUnknownUserAgent() {
         List<Feature> features = Arrays.asList(new Feature("default"));
         Query query = new Query.Builder()
             .includeFeatures(features)
             .setLoadOnUnknownUA(false)
             .build();
-        String actual = getPolyfillsRawSources("firefox/1", query);
-        String expected = "";
-        assertEquals(expected, actual);
+        List<Polyfill> polyfills = service.getPolyfills("firefox/1", query);
+        assertEquals("", polyfillListToString(polyfills));
     }
 
     @Test
-    public void testFeaturesAlwaysLoaded() {
+    public void testGetPolyfillsFeaturesAlwaysLoaded() {
         List<Feature> features = Arrays.asList(new Feature("default", false, true));
         Query query = new Query.Builder().includeFeatures(features).build();
-        String actual = getPolyfillsRawSources("firefox/5", query);
-        String expected = getMockRawSources("c", "b", "d", "a");
-        assertEquals(expected, actual);
+        List<Polyfill> polyfills = service.getPolyfills("firefox/5", query);
+        assertEquals("cbda", polyfillListToString(polyfills));
     }
 
     @Test
-    public void testUserAgentNotMeetBaselineNullifyAlwaysFlag() {
+    public void testGetPolyfillsUserAgentNotMeetBaselineNullifyAlwaysFlag() {
         List<Feature> features = Arrays.asList(new Feature("default", false, true));
         Query query = new Query.Builder()
             .includeFeatures(features)
             .setLoadOnUnknownUA(false)
             .build();
-        String actual = getPolyfillsRawSources("firefox/1", query);
-        String expected = "";
-        assertEquals(expected, actual);
+        List<Polyfill> polyfills = service.getPolyfills("firefox/1", query);
+        assertEquals("", polyfillListToString(polyfills));
     }
 
     @Test
-    public void testNoFeaturesShouldReturnEmpty() {
+    public void testGetPolyfillsNoFeatures() {
         List<Feature> features = Collections.emptyList();
         Query query = new Query.Builder().includeFeatures(features).build();
-        String actual = getPolyfillsRawSources(null, query);
-        String expected = "";
-        assertEquals(expected, actual);
+        List<Polyfill> polyfills = service.getPolyfills("chrome/30", query);
+        assertEquals("", polyfillListToString(polyfills));
     }
 
     @Test
-    public void testSearchBySingleFeature() {
+    public void testGetPolyfillsSingleFeature() {
         List<Feature> features = Arrays.asList(new Feature("c"));
         Query query = new Query.Builder().includeFeatures(features).build();
-        String actual = getPolyfillsRawSources(null, query);
-        String expected = getMockRawSources("c");
-        assertEquals(expected, actual);
+        List<Polyfill> polyfills = service.getPolyfills("chrome/30", query);
+        assertEquals("c", polyfillListToString(polyfills));
     }
 
     @Test
-    public void testSearchByMultipleFeatures() {
+    public void testGetPolyfillsMultipleFeatures() {
         List<Feature> features = Arrays.asList(new Feature("c"), new Feature("e"));
         Query query = new Query.Builder().includeFeatures(features).build();
-        String actual = getPolyfillsRawSources(null, query);
-        String expected = getMockRawSources("c", "e");
-        assertEquals(expected, actual);
+        List<Polyfill> polyfills = service.getPolyfills("chrome/30", query);
+        assertEquals("ce", polyfillListToString(polyfills));
     }
 
     @Test
-    public void testSearchBySingleAlias() {
+    public void testGetPolyfillsSingleAlias() {
         List<Feature> features = Arrays.asList(new Feature("foo"));
         Query query = new Query.Builder().includeFeatures(features).build();
-        String actual = getPolyfillsRawSources(null, query);
-        String expected = getMockRawSources("c", "e");
-        assertEquals(expected, actual);
+        List<Polyfill> polyfills = service.getPolyfills("chrome/30", query);
+        assertEquals("ce", polyfillListToString(polyfills));
     }
 
     @Test
-    public void testSearchByMultipleAliases() {
+    public void testGetPolyfillsMultipleAliases() {
         List<Feature> features = Arrays.asList(new Feature("default"), new Feature("foo"));
         Query query = new Query.Builder().includeFeatures(features).build();
-        String actual = getPolyfillsRawSources(null, query);
-        String expected = getMockRawSources("c", "e", "b", "d", "a");
-        assertEquals(expected, actual);
+        List<Polyfill> polyfills = service.getPolyfills("chrome/30", query);
+        assertEquals("cebda", polyfillListToString(polyfills));
     }
 
     @Test
-    public void testSearchByMixingAliasAndFeature() {
+    public void testGetPolyfillsMixingAliasAndFeature() {
         List<Feature> features = Arrays.asList(new Feature("default"), new Feature("e"));
         Query query = new Query.Builder().includeFeatures(features).build();
-        String actual = getPolyfillsRawSources(null, query);
-        String expected = getMockRawSources("c", "e", "b", "d", "a");
-        assertEquals(expected, actual);
+        List<Polyfill> polyfills = service.getPolyfills("chrome/30", query);
+        assertEquals("cebda", polyfillListToString(polyfills));
     }
 
     @Test
-    public void testExcludesFeatures() {
+    public void testGetPolyfillsExcludesFeatures() {
         List<Feature> features = Arrays.asList(new Feature("default"));
         Query query = new Query.Builder()
             .includeFeatures(features)
             .excludeFeatures("c", "b")
             .build();
-        String actual = getPolyfillsRawSources(null, query);
-        String expected = getMockRawSources("d", "a");
-        assertEquals(expected, actual);
+        List<Polyfill> polyfills = service.getPolyfills("chrome/30", query);
+        assertEquals("da", polyfillListToString(polyfills));
     }
 
     @Test
-    public void testCannotExcludeAlias() {
+    public void testGetPolyfillsCannotExcludeAlias() {
         List<Feature> features = Arrays.asList(new Feature("default"));
         Query query = new Query.Builder()
             .includeFeatures(features)
             .excludeFeatures("es6")
             .build();
-        String actual = getPolyfillsRawSources(null, query);
-        String expected = getMockRawSources("c", "b", "d", "a");
-        assertEquals(expected, actual);
+        List<Polyfill> polyfills = service.getPolyfills("chrome/30", query);
+        assertEquals("cbda", polyfillListToString(polyfills));
     }
 
     @Test
-    public void testDoMinify() {
-        List<Feature> features = Arrays.asList(new Feature("default"));
-        Query query = new Query.Builder().includeFeatures(features).build();
-        String actual = getPolyfillsMinSources(null, query);
-        String expected = getMockMinSources("c", "b", "d", "a");
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    public void testLoadOnUnknownUA() {
+    public void testGetPolyfillsLoadOnUnknownUA() {
         List<Feature> features = Arrays.asList(new Feature("c"));
         Query query = new Query.Builder()
             .includeFeatures(features)
             .setLoadOnUnknownUA(true)
             .build();
-        String actual = getPolyfillsRawSources("unknown/0.0.0", query);
-        String expected = getMockRawSources("c");
+        List<Polyfill> polyfills = service.getPolyfills("unknown/0.0.0", query);
+        assertEquals("c", polyfillListToString(polyfills));
+    }
+
+    @Test
+    public void testGetPolyfillsSourceDefaultServiceConfigWithoutQuery() {
+        String actual = service.getPolyfillsSource("chrome/30");
+        assertEquals("", actual);
+    }
+
+    @Test
+    public void testGetPolyfillsSourceDefaultServiceConfig() {
+        List<Feature> features = Arrays.asList(new Feature("default"));
+        Query query = new Query.Builder().includeFeatures(features).build();
+        String actual = service.getPolyfillsSource("chrome/30", query);
+        String expected = "(function(undefined) {if(!(c.detectSource)){c.min}if(!(b.detectSource)){b.min}if(!(d.detectSource)){d.min}if(!(a.detectSource)){a.min}}).call('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});";
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetPolyfillsSourceQueryOverrideDefault() {
+        List<Feature> features = Arrays.asList(new Feature("default"));
+        Query query = new Query.Builder()
+            .setGatedForAll(false)
+            .includeFeatures(features)
+            .build();
+        String actual = service.getPolyfillsSource("chrome/30", query);
+        String expected = "(function(undefined) {c.minb.mind.mina.min}).call('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});";
         assertEquals(expected, actual);
     }
 
     /****************************************************************
      * Helpers
      ****************************************************************/
-    private String getMockRawSources(String ... featureNames) {
-        return getMockSources(Arrays.asList(featureNames), false);
-    }
-
-    private String getMockMinSources(String ... featureNames) {
-        return getMockSources(Arrays.asList(featureNames), true);
-    }
-
-    private String getMockSources(List<String> featureNameList, boolean doMinify) {
-        return featureNameList.stream()
-                .map(featureName -> featureName + (doMinify ? ".min" : ".raw"))
-                .collect(Collectors.joining());
-    }
-
-    private String getPolyfillsRawSources(String uaString, Query query) {
-        return getPolyfillsSources(uaString, query, false);
-    }
-
-    private String getPolyfillsMinSources(String uaString, Query query) {
-        return getPolyfillsSources(uaString, query, true);
-    }
-
-    private String getPolyfillsSources(String uaString, Query query, boolean minify) {
-        return polyfillService.getPolyfills(uaString, query).stream()
-                .map(polyfill -> minify ? polyfill.getMinSource() : polyfill.getRawSource())
-                .collect(Collectors.joining());
+    private String polyfillListToString(List<Polyfill> polyfills) {
+        return polyfills.stream()
+            .map(polyfill -> polyfill.getName())
+            .collect(Collectors.joining());
     }
 }

--- a/polyfill-service-api/src/test/java/org/polyfillservice/api/services/XmlServiceConfigLoaderServiceTest.java
+++ b/polyfill-service-api/src/test/java/org/polyfillservice/api/services/XmlServiceConfigLoaderServiceTest.java
@@ -3,6 +3,8 @@ package org.polyfillservice.api.services;
 import org.junit.Test;
 import org.polyfillservice.api.components.PolyfillServiceConfigFileLocation;
 import org.polyfillservice.api.components.ServiceConfig;
+import org.polyfillservice.api.interfaces.PolyfillServiceConfigLocation;
+import org.polyfillservice.api.interfaces.ServiceConfigLoaderService;
 
 import java.io.File;
 import java.util.Arrays;
@@ -14,34 +16,44 @@ import static org.junit.Assert.assertEquals;
  */
 public class XmlServiceConfigLoaderServiceTest {
 
-    private final XmlServiceConfigLoaderService serviceConfigLoaderService = new XmlServiceConfigLoaderService();
+    private final ServiceConfigLoaderService service = new XmlServiceConfigLoaderService();
 
+    /**
+     * Should load service config with fields mapped correctly
+     */
     @Test
     public void testLoadConfig() {
-        PolyfillServiceConfigFileLocation serviceConfigLocation = new PolyfillServiceConfigFileLocation(
+        PolyfillServiceConfigLocation serviceConfigLocation = new PolyfillServiceConfigFileLocation(
             new File("./src/test/resources/service_configs/config.xml"));
-        ServiceConfig actualConfig = serviceConfigLoaderService.loadConfig(serviceConfigLocation);
+        ServiceConfig actualConfig = service.loadConfig(serviceConfigLocation);
         ServiceConfig expectedConfig = new ServiceConfig.Builder()
             .setPolyfills(Arrays.asList("a.a", "a.b", "c"))
             .setGated(false)
             .setMinify(false)
             .setLoadOnUnknownUA(false)
+            .setDebugMode(true)
             .build();
         assertEquals(expectedConfig.toString(), actualConfig.toString());
     }
 
+    /**
+     * Should return service config with default settings when unable to load service config
+     */
     @Test
     public void testLoadConfigWithInvalidPath() {
-        PolyfillServiceConfigFileLocation serviceConfigLocation = new PolyfillServiceConfigFileLocation(
+        PolyfillServiceConfigLocation serviceConfigLocation = new PolyfillServiceConfigFileLocation(
             new File("wrong/path"));
-        ServiceConfig actualConfig = serviceConfigLoaderService.loadConfig(serviceConfigLocation);
+        ServiceConfig actualConfig = service.loadConfig(serviceConfigLocation);
         ServiceConfig expectedConfig = new ServiceConfig.Builder().build();
         assertEquals(expectedConfig.toString(), actualConfig.toString());
     }
 
+    /**
+     * Should return service config with default settings when locator is null
+     */
     @Test
     public void testLoadConfigWithNull() {
-        ServiceConfig actualConfig = serviceConfigLoaderService.loadConfig(null);
+        ServiceConfig actualConfig = service.loadConfig(null);
         ServiceConfig expectedConfig = new ServiceConfig.Builder().build();
         assertEquals(expectedConfig.toString(), actualConfig.toString());
     }

--- a/polyfill-service-api/src/test/resources/service_configs/config.xml
+++ b/polyfill-service-api/src/test/resources/service_configs/config.xml
@@ -3,6 +3,7 @@
     <gated>false</gated>
     <minify>false</minify>
     <load-on-unknown-ua>false</load-on-unknown-ua>
+    <debug-mode>true</debug-mode>
     <polyfills>
         <polyfill>a.a</polyfill>
         <polyfill>a.b</polyfill>

--- a/polyfill-service-perf/src/main/java/org/polyfillservice/perf/services/StdOutPerfReportService.java
+++ b/polyfill-service-perf/src/main/java/org/polyfillservice/perf/services/StdOutPerfReportService.java
@@ -56,8 +56,14 @@ public class StdOutPerfReportService implements PerfReportService {
 
     @PostConstruct
     private void init() {
-        rawSourceQuery = new Query.Builder(defaultQuery.getFeatures()).setMinify(false).build();
-        minSourceQuery = new Query.Builder(defaultQuery.getFeatures()).setMinify(true).build();
+        rawSourceQuery = new Query.Builder()
+            .includeFeatures(this.defaultQuery.getFeatures())
+            .setMinify(false)
+            .build();
+        minSourceQuery = new Query.Builder()
+            .includeFeatures(this.defaultQuery.getFeatures())
+            .setMinify(true)
+            .build();
     }
 
     @Override

--- a/polyfill-service-rest/src/main/java/org/polyfillservice/rest/controllers/PolyfillController.java
+++ b/polyfill-service-rest/src/main/java/org/polyfillservice/rest/controllers/PolyfillController.java
@@ -66,15 +66,17 @@ public class PolyfillController {
         boolean isAlwaysForAll = globalFlags.contains(Feature.ALWAYS);
         boolean isGatedForAll = globalFlags.contains(Feature.GATED);
 
-        Query query = new Query.Builder(featuresRequested)
-            .setLoadOnUnknownUA(loadOnUnknown)
+        Query query = new Query.Builder()
+            .includeFeatures(featuresRequested)
             .excludeFeatures(featuresToExclude)
             .setMinify(minify)
-            .setAlwaysForAll(isAlwaysForAll)
+            .setAlwaysLoadForAll(isAlwaysForAll)
             .setGatedForAll(isGatedForAll)
+            .setLoadOnUnknownUA(loadOnUnknown)
+            .setDebugMode(true)
             .build();
 
-        return polyfillService.getPolyfillsSource(uaString, query, true);
+        return polyfillService.getPolyfillsSource(uaString, query);
     }
 
     private List<Feature> getFeatures(Map<String, String> params) {

--- a/polyfill-service-web/src/main/java/org/polyfillservice/web/controllers/TestController.java
+++ b/polyfill-service-web/src/main/java/org/polyfillservice/web/controllers/TestController.java
@@ -59,7 +59,8 @@ public class TestController {
         String uaString = "targeted".equals(mode) ? params.getOrDefault(UA_OVERRIDE, headerUA) : null;
 
         List<Feature> reqFeatureList = Collections.singletonList(new Feature(featureReq));
-        Query query = new Query.Builder(reqFeatureList)
+        Query query = new Query.Builder()
+            .includeFeatures(reqFeatureList)
             .setIncludeDependencies(false)
             .setLoadOnUnknownUA(false)
             .build();


### PR DESCRIPTION
Slight API changes, but probably won't break anyone since these are not doc'ed anywhere.
Will upgrade to v2.0.0 if this is approved.

Tested in Aura :)

Changes:
- #194
  - debugMode is now part of service config and query options
  - link service config to default query
  - user can pass a dynamic query object when getting polyfills. unset fields will get the defaults from service config
- Query object API changes // needed for the above
- remove getPolyfillSource(uaString, query, isDebugMode) // not needed with the new changes
- make naming of some variables more consistent in Query.class and ServiceConfig.class
- tests updates based on api changes
- more tests